### PR TITLE
Fix vector

### DIFF
--- a/include/vector.hpp
+++ b/include/vector.hpp
@@ -155,6 +155,7 @@ namespace ds {
             _capacity = std::move(other._capacity);
             _values = other._values;
             other._values = nullptr;
+            return *this;
         }
 
         Vector<T> &operator=(std::initializer_list<T> list) {

--- a/tests/vector_test.cpp
+++ b/tests/vector_test.cpp
@@ -139,14 +139,6 @@ TEST(VectorTest, CheckFront) {
     ds::Vector<int> v(VECTOR_SIZE);
     v[0] = FIRST_VALUE;
     EXPECT_EQ(v.front(), FIRST_VALUE) << "First value should be " << FIRST_VALUE;
-
-    ds::Vector<int> empty_vector;
-    EXPECT_EXIT({
-        auto i = empty_vector.front();
-        i++;
-    },
-                ::testing::KilledBySignal(SIGSEGV), ".*")
-            << "Expect failure if used on empty vector";
 }
 
 TEST(VectorTest, CheckBack) {


### PR DESCRIPTION
With this pull request we fix two issues of Vector:

1.  A missing return statement on the move assignment operator.
2.  The behavior of `front()` when called on an empty vector is undefined. Thus, we remove the test that checks for a SEGFAULT if that occurs, as we were getting different behaviors depending on whether the code was compiled on debug or release mode.